### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "prestart": "node ./node_modules/gulp/bin/gulp.js",
-    "start": "node ./node_modules/supervisor/lib/cli-wrapper.js -w index.js,lib index.js",
-    "test": "./node_modules/mocha/bin/mocha --recursive"
+    "prestart": "gulp",
+    "start": "supervisor -w index.js,lib index.js",
+    "test": "mocha --recursive"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The scripts in `package.json` are magic in that you can use commands that are created by dependencies. So we don't have to do `node ./node_modules/gulp/bin/gulp.js`, it can just be `gulp`.
