### PR TITLE
Refactor report-parser and add tests.

### DIFF
--- a/lib/util/report-parser.js
+++ b/lib/util/report-parser.js
@@ -153,6 +153,36 @@ function parseV3Report(reportBytes) {
   return report;
 }
 
+function parseV4Report(reportBytes) {
+  if (reportBytes.length < 12) {
+    throw new Error('Invalid v4 report. Bad report length: ' +
+                    reportBytes.length);
+  }
+
+  var report = {};
+
+  report.version = 4;
+  report.batteryVoltage = getBatteryVoltage(reportBytes.readUInt16LE(2));
+  report.uuid = reportBytes.readUInt32LE(4);
+  report.timestamp = getTimestamp(reportBytes.readUInt32LE(8));
+
+  report.entries = [];
+  for (var index = 12; index + 9 <= reportBytes.length; index += 9) {
+
+    if (reportBytes.readUInt32LE(index) === 0xFFFFFFFF) {
+      continue;
+    }
+
+    report.entries.push({
+      timestamp: getTimestamp(reportBytes.readUInt32LE(index)),
+      value: reportBytes.readUInt32LE(index + 4),
+      streamID: reportBytes[index + 8]
+    });
+  }
+
+  return report;
+}
+
 function parseReport(reportValue) {
   var reportBytes = new Buffer(reportValue, 'base64');
 
@@ -176,6 +206,10 @@ function parseReport(reportValue) {
 
   if (version === 3) {
     return parseV3Report(reportBytes);
+  }
+
+  if (version === 4) {
+    return parseV4Report(reportBytes);
   }
 
   throw new Error('Invalid report. Bad version: ' + version);

--- a/lib/util/report-parser.js
+++ b/lib/util/report-parser.js
@@ -1,167 +1,184 @@
-function getBatteryVoltage( rawValue ) {
+function getBatteryVoltage(rawValue) {
   return rawValue / 1024 * 2.78 * 2;
 }
 
-var agg_names = ['count','sum','mean','<none>','<none>','min','max'];
-var interval_types = ['second', 'minute', 'hour', 'day'];
+function getTimestamp(rawValue) {
+  // Timestamp starts in the year 2000.
+  return new Date(1000 * (rawValue + 946684800));
+}
 
-function parseReport( reportValue ) {
-  var reportBytes = new Buffer( reportValue, 'base64' );
+function getInterval(reportBytes, index) {
+  var interval = reportBytes[index];
+
+  return {
+    type: interval & 0xF,
+    step: interval >> 4,
+    count: reportBytes[index + 1]
+  };
+}
+
+function getAggregateNames(reportBytes, index) {
+  var names = ['count', 'sum', 'mean', '<none>', '<none>', 'min', 'max'];
+
+  var aggregates = [];
+  var bitset = reportBytes[index];
+
+  for (var i = 0; i < 8; i++) {
+    if (bitset & (0x1 << i)) {
+      aggregates.push(names[i]);
+    }
+  }
+
+  return aggregates;
+}
+
+function getAggregateValues(reportBytes, index, aggregates) {
+  var values = {};
+
+  aggregates.forEach(function(aggregate) {
+    values[aggregate] = reportBytes.readUInt16LE(index);
+    index += 2;
+  });
+
+  return values;
+}
+
+function getIntervalAggregateValues(reportBytes, index, aggregates, count) {
+  var values = [];
+
+  for (var i = 0; i < count; i++) {
+    values.push(getAggregateValues(reportBytes, index, aggregates));
+    index += 2 * aggregates.length;
+  }
+
+  return values;
+}
+
+function getAggregates(reportBytes, index, report) {
+  var bulkAggregates = getAggregateNames(reportBytes, index);
+  index += 1;
+
+  var intervalAggregates = getAggregateNames(reportBytes, index);
+  index += 1;
+
+  report.interval = getInterval(reportBytes, index);
+  index += 2;
+
+  report.bulkAggregates =
+    getAggregateValues(reportBytes, index, bulkAggregates);
+  index += 2 * bulkAggregates.length;
+
+  report.intervalAggregates = getIntervalAggregateValues(
+    reportBytes, index, intervalAggregates, report.interval.count);
+}
+
+function parseRegistrationReport(reportBytes, version) {
+  if (version !== 0) {
+    throw new Error('Invalid registration report. Bad version: ' + version);
+  }
+
   var report = {};
-  if ( reportBytes.length == 0 )
-    throw new Error( "MoMo reports must be encoded as base64." );
-  report.version = reportBytes[0];
-  if ( report.version & 0x80 ) {
-    // Registration
-    report.isRegistration = true;
-    report.version &= 0x7F; //Mask out the high registration marker bit.
-    if ( report.version == 0 ) {
-      report.errorCount = reportBytes[1];
-      return report;
-    } else {
-      throw new Error( "Unrecognized registration version." );
-      return;
-    }
+  
+  report.version = version;
+  report.isRegistration = true;
+  report.errorCount = reportBytes[1];
+
+  return report;
+}
+
+function parseV1Report(reportBytes) {
+  if (reportBytes.length !== 104) {
+    throw new Error('Invalid v1 report. Bad report length: ' +
+                    reportBytes.length);
   }
-  else if ( report.version == 1 ) //TODO: Make extensible
-  {
-    if ( reportBytes.length != 104 ) {
-      throw new Error( "Poorly formed report (version 1)" );
-    }
-    report.currentHour = reportBytes[1]
-    report.batteryVoltage = getBatteryVoltage( reportBytes.readUInt16LE(2) );
-    report.hourCount = reportBytes[4];
-    report.eventCount = reportBytes[5]
-    report.sensorType = reportBytes[6];
-    var __unused = reportBytes[7]
-    var bucketString = reportBytes.slice(8);
-    report.buckets = [];
-    for (var i=0; i<24; ++i)
-    {
-      report.buckets[i] = bucketString.readUInt32LE(i*4);
-    }
-    console.log( "Parsed report." );
-    console.log( report );
-    return report;
+
+  var report = {};
+
+  report.version = 1;
+  report.currentHour = reportBytes[1];
+  report.batteryVoltage = getBatteryVoltage(reportBytes.readUInt16LE(2));
+  report.hourCount = reportBytes[4];
+  report.eventCount = reportBytes[5];
+  report.sensorType = reportBytes[6];
+  
+  report.buckets = [];
+  for (var i = 8; i < 104; i += 4) {
+    report.buckets.push(reportBytes.readUInt32LE(i));
   }
-  else if ( report.version == 2 )
-  {
-    if ( reportBytes.length < 16 ) {
-      throw new Error( "Poorly formed report (version 2)" );
-    }
-    report.sensor = reportBytes[1];
-    report.sequence = reportBytes.readUInt16LE(2);
-    report.flags = reportBytes.readUInt16LE(4);
-    report.batteryVoltage = reportBytes.readUInt16LE(6) / 1024 * 2.8 * 2;
-    report.diagnostice = [ reportBytes.readUInt16LE(8), reportBytes.readUInt16LE(10) ];
 
-    var bulkAggregateFunctions = []
-    agg = reportBytes[12]
-    for ( var i = 0; i < 8; ++i )
-    {
-      if ( agg & ( 0x1 << i ) )
-        bulkAggregateFunctions.push( agg_names[i] )
-    }
+  return report;
+}
 
-    var intervalAggregateFunctions = []
-    agg = reportBytes[13]
-    for ( var i = 0; i < 8; ++i )
-    {
-      if ( agg & ( 0x1 << i ) )
-        intervalAggregateFunctions.push( agg_names[i] )
-    }
-
-    var interval_def = reportBytes[14];
-    report.interval = {
-      type: (interval_def & 0xF),
-      step: (interval_def >> 4),
-      count: reportBytes[15]
-    }
-
-    var index = 16;
-    report.bulkAggregates = {};
-    for ( var f in bulkAggregateFunctions )
-    {
-      report.bulkAggregates[bulkAggregateFunctions[f]] = reportBytes.readUInt16LE(index);
-      index += 2;
-    }
-
-    report.intervalAggregates = [];
-    for ( var i = 0; i < report.interval.count; ++i )
-    {
-      var aggregate = {};
-      for ( var f in intervalAggregateFunctions )
-      {
-        aggregate[intervalAggregateFunctions[f]] = reportBytes.readUInt16LE(index);
-        index += 2;
-      }
-      report.intervalAggregates.push( aggregate );
-    }
-    console.log( "Parsed report." );
-    console.log( report );
-    return report;
+function parseV2Report(reportBytes) {
+  if (reportBytes.length < 16) {
+    throw new Error('Invalid v2 report. Bad report length: ' +
+                    reportBytes.length);
   }
-  else if ( report.version == 3 )
-  {
-    if ( reportBytes.length < 16 ) {
-      throw new Error( "Poorly formed report (version 2)" );
-    }
-    report.sequence = reportBytes[1];
-    report.uuid = reportBytes.readUInt32LE(2);
-    report.flags = reportBytes.readUInt16LE(6);
-    report.timestamp = new Date(reportBytes.readUInt32LE(8) + 946684800 ); // timestamp starts in the year 2000
-    report.batteryVoltage = reportBytes.readUInt16LE(12) / 1024 * 2.8 * 2;
 
-    var bulkAggregateFunctions = []
-    agg = reportBytes[14]
-    for ( var i = 0; i < 8; ++i )
-    {
-      if ( agg & ( 0x1 << i ) )
-        bulkAggregateFunctions.push( agg_names[i] )
-    }
+  var report = {};
 
-    var intervalAggregateFunctions = []
-    agg = reportBytes[15]
-    for ( var i = 0; i < 8; ++i )
-    {
-      if ( agg & ( 0x1 << i ) )
-        intervalAggregateFunctions.push( agg_names[i] )
-    }
+  report.version = 2;
+  report.sensor = reportBytes[1];
+  report.sequence = reportBytes.readUInt16LE(2);
+  report.flags = reportBytes.readUInt16LE(4);
+  report.batteryVoltage = getBatteryVoltage(reportBytes.readUInt16LE(6));
 
-    var interval_def = reportBytes[16];
-    report.interval = {
-      type: (interval_def & 0xF),
-      step: (interval_def >> 4),
-      count: reportBytes[17]
-    }
+  report.diagnostics = [
+    reportBytes.readUInt16LE(8),
+    reportBytes.readUInt16LE(10)
+  ];
 
-    var index = 18;
-    report.bulkAggregates = {};
-    for ( var f in bulkAggregateFunctions )
-    {
-      report.bulkAggregates[bulkAggregateFunctions[f]] = reportBytes.readUInt16LE(index);
-      index += 2;
-    }
+  getAggregates(reportBytes, 12, report);
 
-    report.intervalAggregates = [];
-    for ( var i = 0; i < report.interval.count; ++i )
-    {
-      var aggregate = {};
-      for ( var f in intervalAggregateFunctions )
-      {
-        aggregate[intervalAggregateFunctions[f]] = reportBytes.readUInt16LE(index);
-        index += 2;
-      }
-      report.intervalAggregates.push( aggregate );
-    }
-    console.log( "Parsed report." );
-    console.log( report );
-    return report;
+  return report;
+}
+
+function parseV3Report(reportBytes) {
+  if (reportBytes.length < 16) {
+    throw new Error('Invalid v3 report. Bad report length: ' +
+                    reportBytes.length);
   }
-  else
-  {
-    throw new Error( "Unrecognized MoMo report version " + report.version + "." );
+
+  var report = {};
+
+  report.version = 3;
+  report.sequence = reportBytes[1];
+  report.uuid = reportBytes.readUInt32LE(2);
+  report.flags = reportBytes.readUInt16LE(6);
+  report.timestamp = getTimestamp(reportBytes.readUInt32LE(8));
+  report.batteryVoltage = getBatteryVoltage(reportBytes.readUInt16LE(12));
+
+  getAggregates(reportBytes, 14, report);
+
+  return report;
+}
+
+function parseReport(reportValue) {
+  var reportBytes = new Buffer(reportValue, 'base64');
+
+  if (reportBytes.length === 0) {
+    throw new Error('Invalid report. Empty or invalid base64.');
   }
+
+  var version = reportBytes[0];
+
+  if ((version & 0x80) !== 0) {
+    return parseRegistrationReport(reportBytes, version & 0x7F);
+  }
+
+  if (version === 1) {
+    return parseV1Report(reportBytes);
+  }
+
+  if (version === 2) {
+    return parseV2Report(reportBytes);
+  }
+
+  if (version === 3) {
+    return parseV3Report(reportBytes);
+  }
+
+  throw new Error('Invalid report. Bad version: ' + version);
 }
 
 module.exports = parseReport;

--- a/scripts/bot.js
+++ b/scripts/bot.js
@@ -72,9 +72,27 @@ function ConstructV3Report( value ) {
   return bytes.toString('base64');
 }
 
+function ConstructV4Report( value ) {
+  var timestamp = Math.floor((new Date().getTime() - new Date('January 1, 2000 GMT').getTime())/1000);
+  var bytes = new Buffer(102);
+  bytes[0] = 4; //version
+  bytes[1] = 0; // reserved
+  bytes.writeUInt16LE( 650, 2 ); // battery voltage
+  bytes.writeUInt32LE( uuid++, 4 ); // uuid
+  bytes.writeUInt32LE( timestamp, 8 ); // timestamp
+  
+  for ( var i = 0; i < 10; ++i ) {
+    bytes.writeUInt32LE( timestamp - 600 + (i * 60), 12 + (i*9) ); // 10 1 minute values
+    bytes.writeUInt32LE( Math.floor(Math.random()*10000), 12 + (i*9) + 4 ); //value
+    bytes[12+(i*9)+8] = 42; //id
+  }
+  console.log( bytes );
+  return bytes.toString('base64');
+}
+
 function SendFakeReport() {
   var url = 'http://' + hostname + '/gateway/http';
-  var data = ConstructV3Report();
+  var data = ConstructV4Report();
 
   console.log("Sending " + JSON.stringify(data) + " to " + url);
   

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -63,7 +63,7 @@ $.getJSON( "/api/v1/monitors", function(monitors) {
 		}, 0);
 
 		var dailyCount = _.reduce(reports, function(count, current) {
-			var timestamp = new Date(new Date(current['report']['timestamp']).getTime()*1000 + new Date('January 1, 1970 GMT').getTime());
+			var timestamp = new Date(new Date(current['report']['timestamp']).getTime() + new Date('January 1, 1970 GMT').getTime());
 			if ( timestamp > (new Date().setHours(0,0,0,0)) )
 				return count+1;
 			else

--- a/src/js/monitor_client.js
+++ b/src/js/monitor_client.js
@@ -223,12 +223,12 @@ function refresh() {
 		}
 		if ( reports.length == 0 ) // None to add
 			return;
-		$('#last-report-time').text( prettifyTimeDelta(new Date(reports[0].report.timestamp).getTime()*1000, new Date().getTime()) + " ago" );
+		$('#last-report-time').text( prettifyTimeDelta(new Date(reports[0].report.timestamp).getTime(), new Date().getTime()) + " ago" );
 
 		_.forEachRight(reports, function(r) {
 			var item = [];
 			_.fill(item, null,  0, _.keys(keys).length+1);
-			item[0] = new Date(r.report.timestamp).getTime()*1000 + new Date('January 1, 1970 GMT').getTime();
+			item[0] = new Date(r.report.timestamp).getTime() + new Date('January 1, 1970 GMT').getTime();
 			item[0] = new Date(item[0]);
 			item[_.indexOf(_.keys(keys), 'battery')+1] = r.report.batteryVoltage;
 			_.forEach( r.report.bulkAggregates, function(val, key) {

--- a/src/js/reports_client.js
+++ b/src/js/reports_client.js
@@ -26,7 +26,7 @@ $(function() {
       url: '/api/v1/reports',
       dataSrc: function( json ) {
         for ( var i in json ) {
-          var timestamp = new Date(new Date(json[i]['report']['timestamp']).getTime()*1000 + new Date('January 1, 1970 GMT').getTime());
+          var timestamp = new Date(new Date(json[i]['report']['timestamp']).getTime() + new Date('January 1, 1970 GMT').getTime());
           json[i]['timestamp'] = timestamp.toDateString() + " " + timestamp.getHours() + ":" + timestamp.getMinutes();
           json[i]['monitors_id'] = '<a href="monitor.html?id='+json[i]['monitors_id']+'">' + escapeHtml(json[i]['report']['uuid'])||"" + '</a>';
           json[i]['batteryVoltage'] = escapeHtml(json[i]['report']['batteryVoltage'])||"";

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -1,0 +1,260 @@
+/* global describe, it */
+
+var parseReport = require('../lib/util/report-parser');
+var expect = require('expect.js');
+
+function getBatteryVoltage(rawValue) {
+  return rawValue / 1024 * 2.78 * 2;
+}
+
+function getReportTimestamp(date) {
+  return Math.floor((date - new Date('2000-01-01 UTC')) / 1000);
+}
+
+var aggregates = {
+  count: 1 << 0,
+  sum: 1 << 1,
+  mean: 1 << 2,
+  min: 1 << 5,
+  max: 1 << 6
+};
+
+describe('report parser', function() {
+
+  it('throws parsing an empty report', function() {
+    function parseEmpty() {
+      return parseReport('');
+    }
+
+    expect(parseEmpty).to.throwError();
+  });
+
+  it('throws parsing a bad version', function() {
+    var version = 4;
+
+    var bytes = new Buffer(1);
+    bytes[0] = version;
+
+    function parseBadVersion() {
+      return parseReport(bytes.toString('base64'));
+    }
+
+    expect(parseBadVersion).to.throwError();
+  });
+
+  describe('registration report', function() {
+
+    it('parses report', function() {
+      var version = 0;
+      var errorCount = 123;
+
+      var bytes = new Buffer(2);
+      bytes[0] = 0x80 | version;
+      bytes[1] = errorCount;
+
+      var report = parseReport(bytes.toString('base64'));
+
+      expect(report.version).to.be(version);
+      expect(report.isRegistration).to.be(true);
+      expect(report.errorCount).to.be(errorCount);
+    });
+
+    it('throws parsing a bad version', function() {
+      var version = 1;
+      var errorCount = 123;
+
+      var bytes = new Buffer(2);
+      bytes[0] = 0x80 | version;
+      bytes[1] = errorCount;
+
+      function parseBadVersion() {
+        return parseReport(bytes.toString('base64'));
+      }
+
+      expect(parseBadVersion).to.throwError();
+    });
+  });
+
+  describe('v1 report', function() {
+
+    it('can parse a v1 report', function() {
+      var version = 1;
+      var currentHour = 2;
+      var batteryVoltage = 3;
+      var hourCount = 4;
+      var eventCount = 5;
+      var sensorType = 6;
+
+      var buckets = [];
+      for (var i = 0; i < 24; i++) {
+        buckets.push(i);
+      }
+
+      var bytes = new Buffer(104);
+      bytes[0] = version;
+      bytes[1] = currentHour;
+      bytes.writeUInt16LE(batteryVoltage, 2);
+      bytes[4] = hourCount;
+      bytes[5] = eventCount;
+      bytes[6] = sensorType;
+
+      buckets.forEach(function(bucket, i) {
+        bytes.writeUInt32LE(bucket, 8 + 4 * i);
+      });
+
+      var report = parseReport(bytes.toString('base64'));
+
+      expect(report.version).to.be(1);
+      expect(report.currentHour).to.be(currentHour);
+      expect(report.batteryVoltage).to.be(getBatteryVoltage(batteryVoltage));
+      expect(report.hourCount).to.be(hourCount);
+      expect(report.eventCount).to.be(eventCount);
+      expect(report.sensorType).to.be(sensorType);
+      expect(report.buckets).to.eql(buckets);
+    });
+
+    it('throws parsing a bad report length', function() {
+      var version = 1;
+
+      var bytes = new Buffer(1);
+      bytes[0] = version;
+
+      function parseBadLength() {
+        return parseReport(bytes.toString('base64'));
+      }
+
+      expect(parseBadLength).to.throwError();
+    });
+  });
+
+  describe('v2 report', function() {
+    it('can parse a v2 report', function() {
+      var version = 2;
+      var sensor = 3;
+      var sequence = 4;
+      var flags = 5;
+      var batteryVoltage = 6;
+      var diagnostics = [7, 8];
+      var bulkAggregates = {count: 1, min: 2, max: 3};
+      var intervalAggregates = [
+        {sum: 1, mean: 2},
+        {sum: 3, mean: 4}
+      ];
+      var interval = {type: 3, step: 2, count: intervalAggregates.length};
+
+      var bytes = new Buffer(30);
+      bytes[0] = version;
+      bytes[1] = sensor;
+      bytes.writeUInt16LE(sequence, 2);
+      bytes.writeUInt16LE(flags, 4);
+      bytes.writeUInt16LE(batteryVoltage, 6);
+      bytes.writeUInt16LE(diagnostics[0], 8);
+      bytes.writeUInt16LE(diagnostics[1], 10);
+      bytes[12] = aggregates.count | aggregates.min | aggregates.max;
+      bytes[13] = aggregates.sum | aggregates.mean;
+      bytes[14] = (interval.step << 4) | interval.type;
+      bytes[15] = interval.count;
+
+      bytes.writeUInt16LE(bulkAggregates.count, 16);
+      bytes.writeUInt16LE(bulkAggregates.min, 18);
+      bytes.writeUInt16LE(bulkAggregates.max, 20);
+
+      bytes.writeUInt16LE(intervalAggregates[0].sum, 22);
+      bytes.writeUInt16LE(intervalAggregates[0].mean, 24);
+
+      bytes.writeUInt16LE(intervalAggregates[1].sum, 26);
+      bytes.writeUInt16LE(intervalAggregates[1].mean, 28);
+
+      var report = parseReport(bytes.toString('base64'));
+
+      expect(report.version).to.be(version);
+      expect(report.sensor).to.be(sensor);
+      expect(report.sequence).to.be(sequence);
+      expect(report.flags).to.be(flags);
+      expect(report.batteryVoltage).to.be(getBatteryVoltage(batteryVoltage));
+      expect(report.diagnostics).to.eql(diagnostics);
+      expect(report.interval).to.eql(interval);
+      expect(report.bulkAggregates).to.eql(bulkAggregates);
+      expect(report.intervalAggregates).to.eql(intervalAggregates);
+    });
+
+    it('throws parsing a bad report length', function() {
+      var version = 2;
+
+      var bytes = new Buffer(1);
+      bytes[0] = version;
+
+      function parseBadLength() {
+        return parseReport(bytes.toString('base64'));
+      }
+
+      expect(parseBadLength).to.throwError();
+    });
+  });
+
+  describe('v3 report', function() {
+
+    it('can parse a v3 report', function() {
+      var version = 3;
+      var sequence = 4;
+      var uuid = 5;
+      var flags = 6;
+      var timestamp = new Date('2015-03-11 15:23:59 UTC');
+      var batteryVoltage = 8;
+      var bulkAggregates = {count: 1, min: 2, max: 3};
+      var intervalAggregates = [
+        {sum: 1, mean: 2},
+        {sum: 3, mean: 4}
+      ];
+      var interval = {type: 3, step: 2, count: intervalAggregates.length};
+
+      var bytes = new Buffer(32);
+      bytes[0] = version;
+      bytes[1] = sequence;
+      bytes.writeUInt32LE(uuid, 2);
+      bytes.writeUInt16LE(flags, 6);
+      bytes.writeUInt32LE(getReportTimestamp(timestamp), 8);
+      bytes.writeUInt16LE(batteryVoltage, 12);
+      bytes[14] = aggregates.count | aggregates.min | aggregates.max;
+      bytes[15] = aggregates.sum | aggregates.mean;
+      bytes[16] = (interval.step << 4) | interval.type;
+      bytes[17] = interval.count;
+
+      bytes.writeUInt16LE(bulkAggregates.count, 18);
+      bytes.writeUInt16LE(bulkAggregates.min, 20);
+      bytes.writeUInt16LE(bulkAggregates.max, 22);
+
+      bytes.writeUInt16LE(intervalAggregates[0].sum, 24);
+      bytes.writeUInt16LE(intervalAggregates[0].mean, 26);
+
+      bytes.writeUInt16LE(intervalAggregates[1].sum, 28);
+      bytes.writeUInt16LE(intervalAggregates[1].mean, 30);
+
+      var report = parseReport(bytes.toString('base64'));
+
+      expect(report.version).to.be(version);
+      expect(report.sequence).to.be(sequence);
+      expect(report.uuid).to.be(uuid);
+      expect(report.flags).to.be(flags);
+      expect(report.timestamp).to.eql(timestamp);
+      expect(report.batteryVoltage).to.be(getBatteryVoltage(batteryVoltage));
+      expect(report.interval).to.eql(interval);
+      expect(report.bulkAggregates).to.eql(bulkAggregates);
+      expect(report.intervalAggregates).to.eql(intervalAggregates);
+    });
+
+    it('throws parsing a bad report length', function() {
+      var version = 3;
+
+      var bytes = new Buffer(1);
+      bytes[0] = version;
+
+      function parseBadLength() {
+        return parseReport(bytes.toString('base64'));
+      }
+
+      expect(parseBadLength).to.throwError();
+    });
+
+  });
+});


### PR DESCRIPTION
I'm not sure whether this is something that you're interested in, but this change refactors report parsing. It breaks parsing into many functions and removes duplication. It also fixes a few bugs:
- Timestamps in v3 reports were not processed correctly (needed to multiply by 1000).
- Fixed typo in v2 reports (`diagnostice` -> `diagnostics`)
- Used `getBatteryVoltage` everywhere to get consistent numbers across all report types.

I also added tests to get to 100% code and branch coverage, though the tests aren't exhaustive.
