### PR TITLE
Support V4 reports and fix report timestamp processing.

### DIFF
--- a/lib/util/report-parser.js
+++ b/lib/util/report-parser.js
@@ -5,6 +5,11 @@ function getBatteryVoltage( rawValue ) {
 var agg_names = ['count','sum','mean','<none>','<none>','min','max'];
 var interval_types = ['second', 'minute', 'hour', 'day'];
 
+function convertToJSTimestamp( deviceTimestamp ) {
+  deviceTimestamp += 946684800; // timestamp starts in the year 2000
+  deviceTimestamp *= 1000; // ms to s
+  return deviceTimestamp;
+}
 function parseReport( reportValue ) {
   var reportBytes = new Buffer( reportValue, 'base64' );
   var report = {};
@@ -109,7 +114,7 @@ function parseReport( reportValue ) {
     report.sequence = reportBytes[1];
     report.uuid = reportBytes.readUInt32LE(2);
     report.flags = reportBytes.readUInt16LE(6);
-    report.timestamp = new Date(reportBytes.readUInt32LE(8) + 946684800 ); // timestamp starts in the year 2000
+    report.timestamp = new Date( convertToJSTimestamp( reportBytes.readUInt32LE(8) ) );
     report.batteryVoltage = reportBytes.readUInt16LE(12) / 1024 * 2.8 * 2;
 
     var bulkAggregateFunctions = []
@@ -156,6 +161,40 @@ function parseReport( reportValue ) {
     }
     console.log( "Parsed report." );
     console.log( report );
+    return report;
+  }
+  else if ( report.version == 4 )
+  {
+    // Byte 1 reserved, unused.
+    report.batteryVoltage = reportBytes.readUInt16LE(2) / 1024 * 2.8 * 2;
+    report.uuid = reportBytes.readUInt32LE(4);
+    report.timestamp = new Date( convertToJSTimestamp( reportBytes.readUInt32LE(8) ) );
+    report.entries = [];
+    var i = 12;
+    while ( i < reportBytes.length )
+    {
+      if ( i + 9 >= reportBytes.length )
+      {
+        console.error("Bad report format, dropped " + (reportBytes.length - i) + "bytes");
+        break;
+      }
+      var entry = {
+        timestamp: new Date( convertToJSTimestamp( reportBytes.readUInt32LE(i) ) ),
+        value: reportBytes.readUInt32LE(i+4),
+        streamID: reportBytes[i+8]
+      }
+
+      if ( reportBytes.readUInt32LE(i) == 0xFFFFFFFF )
+        console.error("Dummy report entry encountered. Skipping.")
+      else
+        report.entries.push(entry);
+      
+      i += 9;
+    }
+
+    console.log( "Parsed report." );
+    console.log( report );
+
     return report;
   }
   else

--- a/scripts/bot.js
+++ b/scripts/bot.js
@@ -71,10 +71,27 @@ function ConstructV3Report( value ) {
   }
   return bytes.toString('base64');
 }
+function ConstructV4Report( value ) {
+  var timestamp = Math.floor((new Date().getTime() - new Date('January 1, 2000 GMT').getTime())/1000);
+  var bytes = new Buffer(102);
+  bytes[0] = 4; //version
+  bytes[1] = 0; // reserved
+  bytes.writeUInt16LE( 650, 2 ); // battery voltage
+  bytes.writeUInt32LE( uuid++, 4 ); // uuid
+  bytes.writeUInt32LE( timestamp, 8 ); // timestamp
+  
+  for ( var i = 0; i < 10; ++i ) {
+    bytes.writeUInt32LE( timestamp - 600 + (i * 60), 12 + (i*9) ); // 10 1 minute values
+    bytes.writeUInt32LE( Math.floor(Math.random()*10000), 12 + (i*9) + 4 ); //value
+    bytes[12+(i*9)+8] = 42; //id
+  }
+  console.log( bytes );
+  return bytes.toString('base64');
+}
 
 function SendFakeReport() {
   var url = 'http://' + hostname + '/gateway/http';
-  var data = ConstructV3Report();
+  var data = ConstructV4Report();
 
   console.log("Sending " + JSON.stringify(data) + " to " + url);
   

--- a/src/js/monitor_client.js
+++ b/src/js/monitor_client.js
@@ -223,12 +223,12 @@ function refresh() {
 		}
 		if ( reports.length == 0 ) // None to add
 			return;
-		$('#last-report-time').text( prettifyTimeDelta(new Date(reports[0].report.timestamp).getTime()*1000, new Date().getTime()) + " ago" );
+		$('#last-report-time').text( prettifyTimeDelta(new Date(reports[0].report.timestamp).getTime(), new Date().getTime()) + " ago" );
 
 		_.forEachRight(reports, function(r) {
 			var item = [];
 			_.fill(item, null,  0, _.keys(keys).length+1);
-			item[0] = new Date(r.report.timestamp).getTime()*1000 + new Date('January 1, 1970 GMT').getTime();
+			item[0] = new Date(r.report.timestamp).getTime() + new Date('January 1, 1970 GMT').getTime();
 			item[0] = new Date(item[0]);
 			item[_.indexOf(_.keys(keys), 'battery')+1] = r.report.batteryVoltage;
 			_.forEach( r.report.bulkAggregates, function(val, key) {

--- a/src/js/reports_client.js
+++ b/src/js/reports_client.js
@@ -26,7 +26,7 @@ $(function() {
       url: '/api/v1/reports',
       dataSrc: function( json ) {
         for ( var i in json ) {
-          var timestamp = new Date(new Date(json[i]['report']['timestamp']).getTime()*1000 + new Date('January 1, 1970 GMT').getTime());
+          var timestamp = new Date(new Date(json[i]['report']['timestamp']).getTime() + new Date('January 1, 1970 GMT').getTime());
           json[i]['timestamp'] = timestamp.toDateString() + " " + timestamp.getHours() + ":" + timestamp.getMinutes();
           json[i]['monitors_id'] = '<a href="monitor.html?id='+json[i]['monitors_id']+'">' + escapeHtml(json[i]['report']['uuid'])||"" + '</a>';
           json[i]['batteryVoltage'] = escapeHtml(json[i]['report']['batteryVoltage'])||"";


### PR DESCRIPTION
V4 reports are simply a stream of streamid-timestamp-value tuples.  Currently V4 reports do not render properly in the portal UI, but nothing should break.

Reports were stored as malformed Date object in the database (using seconds rather than milliseconds)
